### PR TITLE
Allow host machine to access MySQL

### DIFF
--- a/mysql/my.cnf
+++ b/mysql/my.cnf
@@ -44,7 +44,7 @@ skip-external-locking
 #
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
-#bind-address		= 127.0.0.1
+bind-address		= 0.0.0.0
 #
 # * Fine Tuning
 #


### PR DESCRIPTION
Use bind-address=0.0.0.0 in my.cnf to allow host machine to access MySQL server directly.